### PR TITLE
Enhance configuration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/sbstjn/serverless-dynamodb-autoscaling.svg)](https://github.com/sbstjn/serverless-dynamodb-autoscaling/blob/master/LICENSE.md)
 [![Coveralls](https://img.shields.io/coveralls/sbstjn/serverless-dynamodb-autoscaling.svg)](https://coveralls.io/github/sbstjn/serverless-dynamodb-autoscaling)
 
-With this plugin for [serverless](https://serverless.com) you can enable DynamoDB Auto Scaling for tables and *Global Secondary Indexes* easily in your `serverless.yml` configuration file. The plugin supports multiple tables, indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
+With this plugin for [serverless](https://serverless.com) you can enable DynamoDB Auto Scaling for tables and *Global Secondary Indexes* easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
 
 ## Usage
 
@@ -48,7 +48,15 @@ custom:
 
 That's it! With the next deployment serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its **Global Secondary Index** called `custom-index-name`. 
 
-You must of course provide at least a configuration for `read` or `write` to enable Auto Scaling. The value for `usage` has a default of 75 percent.
+You must of course provide at least a configuration for `read` or `write` to enable Auto Scaling!
+
+### Defaults
+
+```yaml
+usage: 0.75
+minimum: 5
+maximum: 200
+```
 
 ### Index
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ⚡️ Serverless Plugin for DynamoDB Auto Scaling
 
 [![npm](https://img.shields.io/npm/v/serverless-dynamodb-autoscaling.svg)](https://www.npmjs.com/package/serverless-dynamodb-autoscaling)
-[![CircleCI](https://img.shields.io/circleci/project/github/sbstjn/serverless-dynamodb-autoscaling.svg)](https://circleci.com/gh/sbstjn/serverless-dynamodb-autoscaling)
+[![CircleCI](https://img.shields.io/circleci/project/github/sbstjn/serverless-dynamodb-autoscaling/master.svg)](https://circleci.com/gh/sbstjn/serverless-dynamodb-autoscaling)
 [![license](https://img.shields.io/github/license/sbstjn/serverless-dynamodb-autoscaling.svg)](https://github.com/sbstjn/serverless-dynamodb-autoscaling/blob/master/LICENSE.md)
 [![Coveralls](https://img.shields.io/coveralls/sbstjn/serverless-dynamodb-autoscaling.svg)](https://coveralls.io/github/sbstjn/serverless-dynamodb-autoscaling)
 
-With this plugin for [serverless](https://serverless.com) you can enable DynamoDB Auto Scaling for tables and *Global Secondary Indexes* easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
+With this plugin for [serverless](https://serverless.com) you can enable DynamoDB Auto Scaling for tables and **Global Secondary Indexes** easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
 
 ## Usage
 
@@ -19,8 +19,6 @@ $ yarn add serverless-dynamodb-autoscaling
 $ npm install serverless-dynamodb-autoscaling
 ```
 
-## Configuration
-
 Add the plugin to your `serverless.yml`:
 
 ```yaml
@@ -28,7 +26,9 @@ plugins:
   - serverless-dynamodb-autoscaling
 ```
 
-Configure DynamoDB Auto Scaling in `serverless.yml` with references to your DynamoDB CloudFormation resources for the `table` property. The `index` configuration is optional.
+## Configuration
+
+Configure DynamoDB Auto Scaling in `serverless.yml` with references to your DynamoDB CloudFormation resources for the `table` property. The `index` configuration is optional to apply Auto Scaling *Global Secondary Index*.
 
 ```yaml
 custom:
@@ -46,16 +46,16 @@ custom:
         usage: 0.5        # Targeted usage percentage
 ```
 
-That's it! With the next deployment serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its **Global Secondary Index** called `custom-index-name`. 
+That's it! With the next deployment [serverless](https://serverless.com) will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its *Global Secondary Index* called `custom-index-name`. 
 
-You must of course provide at least a configuration for `read` or `write` to enable Auto Scaling!
+You must provide at least a configuration for `read` or `write` to enable Auto Scaling!
 
 ### Defaults
 
 ```yaml
-usage: 0.75
-minimum: 5
 maximum: 200
+minimum: 5
+usage: 0.75
 ```
 
 ### Index
@@ -64,7 +64,7 @@ If you only want to enable Auto Scaling for the index, use `indexOnly: true` to 
 
 ### API Throtteling
 
-CloudWatch has very strict [API rate limitations](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Index*, request an increase of the rate limits first! Otherwise you might run into an error like this:
+CloudWatch has very strict [API rate limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Indexes*, request an increase of the rate limits first! Otherwise you might run into an error like this:
 
 ```
 An error occurred while provisioning your stack: XYZ - Unable to create alarms for scaling policy XYZ due to reason: 
@@ -73,7 +73,7 @@ Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttli
 
 ## DynamoDB
 
-The example configuration above works fine for a DynamoDB table configuration like this:
+The example serverless configuration above works fine for a DynamoDB table configuration like this:
 
 ```yaml
 resources:

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ plugins:
   - serverless-dynamodb-autoscaling
 ```
 
-Configure DynamoDB Auto Scaling in `serverless.yml`:
+Configure DynamoDB Auto Scaling in `serverless.yml` with references to your DynamoDB CloudFormation resources for the `table` property:
 
 ```yaml
 custom:
   capacities:
-    - name: custom-table  # DynamoDB table name
+    - table: CustomTable  # DynamoDB Resource
       read:
         minimum: 5        # Minimum read capacity
         maximum: 1000     # Maximum read capacity
@@ -42,16 +42,18 @@ custom:
         minimum: 40       # Minimum write capacity
         maximum: 200      # Maximum write capacity
         usage: 0.5        # Targeted usage percentage
-    - name: another-table
+    - table: AnotherTable
       read:
         minimum: 5
         maximum: 1000
         # usage: 0.75 is the default
 ```
 
-That's it! With the next deployment (`sls deploy`) serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB tables `custom-table` and `another-table`.
+That's it! With the next deployment (`sls deploy`) serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and `AnotherTable`.
 
 You must of course provide at least a configuration for `read` or `write` to enable Auto Scaling. The value for `usage` has a default of 75 percent.
+
+**Notice:** *With the relese of `v0.2.x` the plugin introduced a breaking change. Starting with `v0.2.0` you need to provide the CloudFormation reference for the `table` property. In `v0.1.x` the plugin used a `name` property with the DynamoDB table name.*
 
 ## DynamoDB
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/sbstjn/serverless-dynamodb-autoscaling.svg)](https://github.com/sbstjn/serverless-dynamodb-autoscaling/blob/master/LICENSE.md)
 [![Coveralls](https://img.shields.io/coveralls/sbstjn/serverless-dynamodb-autoscaling.svg)](https://coveralls.io/github/sbstjn/serverless-dynamodb-autoscaling)
 
-With this plugin for [serverless](https://serverless.com) you can set DynamoDB Auto Scaling configuratin in your `serverless.yml` file. The plugin supports multiple tables and separate configuration sets for `read` and `write` capacities using AWS [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/). Besides general Auto Scaling for DynamoDB tables, you can easily configure Auto Scaling for *Global Secondary Indexes* as well!
+With this plugin for [serverless](https://serverless.com) you can enable DynamoDB Auto Scaling for tables and *Global Secondary Indexes* easily in your `serverless.yml` configuration file. The plugin supports multiple tables, indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
 
 ## Usage
 
@@ -16,7 +16,7 @@ Add the [NPM package](https://www.npmjs.com/package/serverless-dynamodb-autoscal
 $ yarn add serverless-dynamodb-autoscaling
 
 # Via npm
-$ npm install serverless-dynamodb-autoscaling --save-dev
+$ npm install serverless-dynamodb-autoscaling
 ```
 
 ## Configuration
@@ -28,7 +28,7 @@ plugins:
   - serverless-dynamodb-autoscaling
 ```
 
-Configure DynamoDB Auto Scaling in `serverless.yml` with references to your DynamoDB CloudFormation resources for the `table` property:
+Configure DynamoDB Auto Scaling in `serverless.yml` with references to your DynamoDB CloudFormation resources for the `table` property. The `index` configuration is optional.
 
 ```yaml
 custom:
@@ -46,15 +46,26 @@ custom:
         usage: 0.5        # Targeted usage percentage
 ```
 
-That's it! With the next deployment (`sls deploy`) serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its **Global Secondary Index** called `custom-index-name`. If you only want to enable Auto Scaling for the index, use `indexOnly: true` to skip Auto Scaling for the general DynamoDB table.
+That's it! With the next deployment serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its **Global Secondary Index** called `custom-index-name`. 
 
 You must of course provide at least a configuration for `read` or `write` to enable Auto Scaling. The value for `usage` has a default of 75 percent.
 
-**Notice:** *With the relese of `v0.2.x` the plugin introduced a breaking change. Starting with `v0.2.0` you need to provide the CloudFormation reference for the `table` property. In `v0.1.x` the plugin used a `name` property with the DynamoDB table name.*
+### Index
+
+If you only want to enable Auto Scaling for the index, use `indexOnly: true` to skip Auto Scaling for the general DynamoDB table.
+
+### API Throtteling
+
+CloudWatch has very strict [API rate limitations](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Index*, request an increase of the rate limits first! Otherwise you might run into an error like this:
+
+```
+An error occurred while provisioning your stack: XYZ - Unable to create alarms for scaling policy XYZ due to reason: 
+Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttling; Request ID: XYZ).
+```
 
 ## DynamoDB
 
-The configuration above works fine for a default DynamoDB table configuration.
+The example configuration above works fine for a DynamoDB table configuration like this:
 
 ```yaml
 resources:
@@ -82,15 +93,6 @@ resources:
             ProvisionedThroughput:
               ReadCapacityUnits: 5
               WriteCapacityUnits: 5
-```
-
-## API Throtteling
-
-CloudWatch has very strict [API rate limitations](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Index*, mare sure to request an increase of the rate limits first! Otherwise you might run into an error like this:
-
-```
-An error occurred while provisioning your stack: XYZ - Unable to create alarms for scaling policy XYZ due to reason: 
-Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttling; Request ID: XYZ).
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/sbstjn/serverless-dynamodb-autoscaling.svg)](https://github.com/sbstjn/serverless-dynamodb-autoscaling/blob/master/LICENSE.md)
 [![Coveralls](https://img.shields.io/coveralls/sbstjn/serverless-dynamodb-autoscaling.svg)](https://coveralls.io/github/sbstjn/serverless-dynamodb-autoscaling)
 
-With this plugin for [serverless](https://serverless.com) you can enable DynamoDB Auto Scaling for tables and **Global Secondary Indexes** easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
+With this plugin for [serverless](https://serverless.com), you can enable DynamoDB Auto Scaling for tables and **Global Secondary Indexes** easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
 
 ## Usage
 
@@ -46,7 +46,7 @@ custom:
         usage: 0.5        # Targeted usage percentage
 ```
 
-That's it! With the next deployment [serverless](https://serverless.com) will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its *Global Secondary Index* called `custom-index-name`. 
+That's it! With the next deployment, [serverless](https://serverless.com) will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its *Global Secondary Index* called `custom-index-name`. 
 
 You must provide at least a configuration for `read` or `write` to enable Auto Scaling!
 
@@ -64,7 +64,7 @@ If you only want to enable Auto Scaling for the index, use `indexOnly: true` to 
 
 ### API Throtteling
 
-CloudWatch has very strict [API rate limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Indexes*, request an increase of the rate limits first! Otherwise you might run into an error like this:
+CloudWatch has very strict [API rate limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Indexes*, request an increase of the rate limits first! Otherwise, you might run into an error like this:
 
 ```
 An error occurred while provisioning your stack: XYZ - Unable to create alarms for scaling policy XYZ due to reason: 
@@ -73,7 +73,7 @@ Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttli
 
 ## DynamoDB
 
-The example serverless configuration above works fine for a DynamoDB table configuration like this:
+The example serverless configuration above works fine for a DynamoDB table CloudFormation resource like this:
 
 ```yaml
 resources:
@@ -116,4 +116,4 @@ Feel free to use the code, it's released using the [MIT license](LICENSE.md).
 
 You are welcome to contribute to this project! 😘 
 
-To make sure you have a pleasant experience, please read the [code of conduct](CODE_OF_CONDUCT.md). It outlines core values and believes and will make working together a happier experience.
+To make sure you have a pleasant experience, please read the [code of conduct](CODE_OF_CONDUCT.md). It outlines core values and beliefs and will make working together a happier experience.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/sbstjn/serverless-dynamodb-autoscaling.svg)](https://github.com/sbstjn/serverless-dynamodb-autoscaling/blob/master/LICENSE.md)
 [![Coveralls](https://img.shields.io/coveralls/sbstjn/serverless-dynamodb-autoscaling.svg)](https://coveralls.io/github/sbstjn/serverless-dynamodb-autoscaling)
 
-With this plugin for [serverless](https://serverless.com), you can enable DynamoDB Auto Scaling for tables and **Global Secondary Indexes** easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well separate configuration sets for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
+With this plugin for [serverless](https://serverless.com), you can enable DynamoDB Auto Scaling for tables and **Global Secondary Indexes** easily in your `serverless.yml` configuration file. The plugin supports multiple tables and indexes, as well as separate configuration for `read` and `write` capacities using Amazon's [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/sbstjn/serverless-dynamodb-autoscaling.svg)](https://github.com/sbstjn/serverless-dynamodb-autoscaling/blob/master/LICENSE.md)
 [![Coveralls](https://img.shields.io/coveralls/sbstjn/serverless-dynamodb-autoscaling.svg)](https://coveralls.io/github/sbstjn/serverless-dynamodb-autoscaling)
 
-With this plugin for [serverless](https://serverless.com) you can set DynamoDB Auto Scaling configuratin in your `serverless.yml` file. The plugin supports multiple tables and separate configuration sets for `read` and `write` capacities using AWS [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/).
+With this plugin for [serverless](https://serverless.com) you can set DynamoDB Auto Scaling configuratin in your `serverless.yml` file. The plugin supports multiple tables and separate configuration sets for `read` and `write` capacities using AWS [native DynamoDB Auto Scaling](https://aws.amazon.com/blogs/aws/new-auto-scaling-for-amazon-dynamodb/). Besides general Auto Scaling for DynamoDB tables, you can easily configure Auto Scaling for *Global Secondary Indexes* as well!
 
 ## Usage
 
@@ -34,6 +34,8 @@ Configure DynamoDB Auto Scaling in `serverless.yml` with references to your Dyna
 custom:
   capacities:
     - table: CustomTable  # DynamoDB Resource
+      index:              # List or single index name
+        - custom-index-name
       read:
         minimum: 5        # Minimum read capacity
         maximum: 1000     # Maximum read capacity
@@ -42,14 +44,9 @@ custom:
         minimum: 40       # Minimum write capacity
         maximum: 200      # Maximum write capacity
         usage: 0.5        # Targeted usage percentage
-    - table: AnotherTable
-      read:
-        minimum: 5
-        maximum: 1000
-        # usage: 0.75 is the default
 ```
 
-That's it! With the next deployment (`sls deploy`) serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and `AnotherTable`.
+That's it! With the next deployment (`sls deploy`) serverless will add a CloudFormation configuration to enable Auto Scaling for the DynamoDB resources `CustomTable` and its **Global Secondary Index** called `custom-index-name`. If you only want to enable Auto Scaling for the index, use `indexOnly: true` to skip Auto Scaling for the general DynamoDB table.
 
 You must of course provide at least a configuration for `read` or `write` to enable Auto Scaling. The value for `usage` has a default of 75 percent.
 
@@ -75,6 +72,16 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5
+        GlobalSecondaryIndexes:
+          - IndexName: custom-index-name
+            KeySchema:
+              - AttributeName: key
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
+            ProvisionedThroughput:
+              ReadCapacityUnits: 5
+              WriteCapacityUnits: 5
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ resources:
               WriteCapacityUnits: 5
 ```
 
+## API Throtteling
+
+CloudWatch has very strict [API rate limitations](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)! If you plan to configure Auto Scaling for multiple DynamoDB tables or *Global Secondary Index*, mare sure to request an increase of the rate limits first! Otherwise you might run into an error like this:
+
+```
+An error occurred while provisioning your stack: XYZ - Unable to create alarms for scaling policy XYZ due to reason: 
+Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttling; Request ID: XYZ).
+```
+
 ## License
 
 Feel free to use the code, it's released using the [MIT license](LICENSE.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dynamodb-autoscaling",
-  "description": "Serverless Plugin for Amazon DynamoDB Auto Scaling configuration.",
+  "description": "Serverless Plugin for Amazon DynamoDB Auto Scaling.",
   "version": "0.0.0",
   "main": "src/plugin.js",
   "scripts": {

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -1,6 +1,8 @@
 const util = require('util')
 
-const clean = (input) => input.replace(/[^a-z0-9+]+/gi, '')
+function clean (input) {
+  return input.replace(/[^a-z0-9+]+/gi, '')
+}
 
 function policyScale (table, read, index, stage) {
   return clean(

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -5,9 +5,10 @@ const clean = (input) => input.replace(/[^a-z0-9+]+/gi, '')
 function policyScale (table, read, index, stage) {
   return clean(
     util.format(
-      'Table%sScalingPolicy-%s%s', read ? 'Read' : 'Write',
+      'Table%sScalingPolicy-%s%s%s', read ? 'Read' : 'Write',
       table,
-      index || ''
+      index || '',
+      stage || ''
     )
   )
 }
@@ -15,14 +16,15 @@ function policyScale (table, read, index, stage) {
 function policyRole (table, index, stage) {
   return clean(
     util.format(
-      'DynamoDBAutoscalePolicy-%s%s',
+      'DynamoDBAutoscalePolicy-%s%s%s',
       table,
-      index || ''
+      index || '',
+      stage || ''
     )
   )
 }
 
-function dimension (read, index, stage) {
+function dimension (read, index) {
   return util.format(
     'dynamodb:%s:%sCapacityUnits',
     index ? 'index' : 'table',
@@ -33,10 +35,11 @@ function dimension (read, index, stage) {
 function target (table, read, index, stage) {
   return clean(
     util.format(
-      'AutoScalingTarget%s-%s%s',
+      'AutoScalingTarget%s-%s%s%s',
       read ? 'Read' : 'Write',
       table,
-      index || ''
+      index || '',
+      stage || ''
     )
   )
 }
@@ -53,9 +56,10 @@ function metric (read) {
 function role (table, index, stage) {
   return clean(
     util.format(
-      'DynamoDBAutoscaleRole-%s%s',
+      'DynamoDBAutoscaleRole-%s%s%s',
       table,
-      index || ''
+      index || '',
+      stage || ''
     )
   )
 }

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -2,11 +2,11 @@ const util = require('util')
 
 const clean = (input) => input.replace(/[^a-z0-9+]+/gi, '')
 
-const policyScale = (table, read) => clean(util.format('Table%sScalingPolicy-%s', read ? 'Read' : 'Write', table))
-const policyRole = (table) => clean(util.format('DynamoDBAutoscalePolicy-%s', table))
-const dimension = (read) => util.format('dynamodb:table:%sCapacityUnits', read ? 'Read' : 'Write')
-const target = (table, read) => clean(util.format('AutoScalingTarget%s-%s', read ? 'Read' : 'Write', table))
+const policyScale = (table, read, index) => clean(util.format('Table%sScalingPolicy-%s%s', read ? 'Read' : 'Write', table, index || ''))
+const policyRole = (table, index) => clean(util.format('DynamoDBAutoscalePolicy-%s%s', table, index || ''))
+const dimension = (read, index) => util.format('dynamodb:%s:%sCapacityUnits', index ? 'index' : 'table', read ? 'Read' : 'Write')
+const target = (table, read, index) => clean(util.format('AutoScalingTarget%s-%s%s', read ? 'Read' : 'Write', table, index || ''))
 const metric = (read) => clean(util.format('DynamoDB%sCapacityUtilization', read ? 'Read' : 'Write'))
-const role = (table) => clean(util.format('DynamoDBAutoscaleRole-%s', table))
+const role = (table, index) => clean(util.format('DynamoDBAutoscaleRole-%s%s', table, index || ''))
 
 module.exports = { dimension, metric, policyScale, policyRole, role, target, clean }

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -7,7 +7,8 @@ function clean (input) {
 function policyScale (table, read, index, stage) {
   return clean(
     util.format(
-      'Table%sScalingPolicy-%s%s%s', read ? 'Read' : 'Write',
+      'Table%sScalingPolicy-%s%s%s',
+      read ? 'Read' : 'Write',
       table,
       index || '',
       stage || ''

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -2,7 +2,7 @@ const util = require('util')
 
 const clean = (input) => input.replace(/[^a-z0-9+]+/gi, '')
 
-function policyScale (table, read, index) {
+function policyScale (table, read, index, stage) {
   return clean(
     util.format(
       'Table%sScalingPolicy-%s%s', read ? 'Read' : 'Write',
@@ -12,7 +12,7 @@ function policyScale (table, read, index) {
   )
 }
 
-function policyRole (table, index) {
+function policyRole (table, index, stage) {
   return clean(
     util.format(
       'DynamoDBAutoscalePolicy-%s%s',
@@ -22,7 +22,7 @@ function policyRole (table, index) {
   )
 }
 
-function dimension (read, index) {
+function dimension (read, index, stage) {
   return util.format(
     'dynamodb:%s:%sCapacityUnits',
     index ? 'index' : 'table',
@@ -30,7 +30,7 @@ function dimension (read, index) {
   )
 }
 
-function target (table, read, index) {
+function target (table, read, index, stage) {
   return clean(
     util.format(
       'AutoScalingTarget%s-%s%s',
@@ -50,7 +50,7 @@ function metric (read) {
   )
 }
 
-function role (table, index) {
+function role (table, index, stage) {
   return clean(
     util.format(
       'DynamoDBAutoscaleRole-%s%s',

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -2,11 +2,70 @@ const util = require('util')
 
 const clean = (input) => input.replace(/[^a-z0-9+]+/gi, '')
 
-const policyScale = (table, read, index) => clean(util.format('Table%sScalingPolicy-%s%s', read ? 'Read' : 'Write', table, index || ''))
-const policyRole = (table, index) => clean(util.format('DynamoDBAutoscalePolicy-%s%s', table, index || ''))
-const dimension = (read, index) => util.format('dynamodb:%s:%sCapacityUnits', index ? 'index' : 'table', read ? 'Read' : 'Write')
-const target = (table, read, index) => clean(util.format('AutoScalingTarget%s-%s%s', read ? 'Read' : 'Write', table, index || ''))
-const metric = (read) => clean(util.format('DynamoDB%sCapacityUtilization', read ? 'Read' : 'Write'))
-const role = (table, index) => clean(util.format('DynamoDBAutoscaleRole-%s%s', table, index || ''))
+function policyScale (table, read, index) {
+  return clean(
+    util.format(
+      'Table%sScalingPolicy-%s%s', read ? 'Read' : 'Write',
+      table,
+      index || ''
+    )
+  )
+}
 
-module.exports = { dimension, metric, policyScale, policyRole, role, target, clean }
+function policyRole (table, index) {
+  return clean(
+    util.format(
+      'DynamoDBAutoscalePolicy-%s%s',
+      table,
+      index || ''
+    )
+  )
+}
+
+function dimension (read, index) {
+  return util.format(
+    'dynamodb:%s:%sCapacityUnits',
+    index ? 'index' : 'table',
+    read ? 'Read' : 'Write'
+  )
+}
+
+function target (table, read, index) {
+  return clean(
+    util.format(
+      'AutoScalingTarget%s-%s%s',
+      read ? 'Read' : 'Write',
+      table,
+      index || ''
+    )
+  )
+}
+
+function metric (read) {
+  return clean(
+    util.format(
+      'DynamoDB%sCapacityUtilization',
+      read ? 'Read' : 'Write'
+    )
+  )
+}
+
+function role (table, index) {
+  return clean(
+    util.format(
+      'DynamoDBAutoscaleRole-%s%s',
+      table,
+      index || ''
+    )
+  )
+}
+
+module.exports = {
+  clean,
+  dimension,
+  metric,
+  policyRole,
+  policyScale,
+  role,
+  target
+}

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -1,8 +1,9 @@
 const names = require('./names')
 
 class Policy {
-  constructor (table, value, read, scaleIn, scaleOut) {
+  constructor (table, value, read, scaleIn, scaleOut, index) {
     this.table = table
+    this.index = index
     this.value = parseFloat(value, 10) * 100
     this.read = !!read
     this.scaleIn = parseInt(scaleIn, 10)

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -1,9 +1,10 @@
 const names = require('./names')
 
 class Policy {
-  constructor (table, value, read, scaleIn, scaleOut, index) {
+  constructor (table, value, read, scaleIn, scaleOut, index, stage) {
     this.table = table
     this.index = index
+    this.stage = stage
     this.value = parseFloat(value, 10) * 100
     this.read = !!read
     this.scaleIn = parseInt(scaleIn, 10)
@@ -19,16 +20,16 @@ class Policy {
 
   toJSON () {
     return {
-      [names.policyScale(this.table, this.read, this.index)]: {
+      [names.policyScale(this.table, this.read, this.index, this.stage)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalingPolicy',
         'DependsOn': [
           this.table,
-          names.target(this.table, this.read, this.index)
+          names.target(this.table, this.read, this.index, this.stage)
         ].concat(this.dependencies),
         'Properties': {
-          'PolicyName': names.policyScale(this.table, this.read, this.index),
+          'PolicyName': names.policyScale(this.table, this.read, this.index, this.stage),
           'PolicyType': 'TargetTrackingScaling',
-          'ScalingTargetId': { 'Ref': names.target(this.table, this.read, this.index) },
+          'ScalingTargetId': { 'Ref': names.target(this.table, this.read, this.index, this.stage) },
           'TargetTrackingScalingPolicyConfiguration': {
             'PredefinedMetricSpecification': {
               'PredefinedMetricType': names.metric(this.read)

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -11,7 +11,7 @@ class Policy {
     this.dependencies = []
   }
 
-  setDependencies(list) {
+  setDependencies (list) {
     this.dependencies = list
   }
 

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -11,16 +11,16 @@ class Policy {
 
   toJSON () {
     return {
-      [names.policyScale(this.table, this.read)]: {
+      [names.policyScale(this.table, this.read, this.index)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalingPolicy',
         'DependsOn': [
           this.table,
-          names.target(this.table, this.read)
+          names.target(this.table, this.read, this.index)
         ],
         'Properties': {
-          'PolicyName': names.policyScale(this.table, this.read),
+          'PolicyName': names.policyScale(this.table, this.read, this.index),
           'PolicyType': 'TargetTrackingScaling',
-          'ScalingTargetId': { 'Ref': names.target(this.table, this.read) },
+          'ScalingTargetId': { 'Ref': names.target(this.table, this.read, this.index) },
           'TargetTrackingScalingPolicyConfiguration': {
             'PredefinedMetricSpecification': {
               'PredefinedMetricType': names.metric(this.read)

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -8,6 +8,11 @@ class Policy {
     this.read = !!read
     this.scaleIn = parseInt(scaleIn, 10)
     this.scaleOut = parseInt(scaleOut, 10)
+    this.dependencies = []
+  }
+
+  setDependencies(list) {
+    this.dependencies = list
   }
 
   toJSON () {
@@ -17,7 +22,7 @@ class Policy {
         'DependsOn': [
           this.table,
           names.target(this.table, this.read, this.index)
-        ],
+        ].concat(this.dependencies),
         'Properties': {
           'PolicyName': names.policyScale(this.table, this.read, this.index),
           'PolicyType': 'TargetTrackingScaling',

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -13,6 +13,8 @@ class Policy {
 
   setDependencies (list) {
     this.dependencies = list
+
+    return this
   }
 
   toJSON () {

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -13,6 +13,10 @@ class Policy {
     return {
       [names.policyScale(this.table, this.read)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalingPolicy',
+        'DependsOn': [
+          this.table,
+          names.target(this.table, this.read)
+        ],
         'Properties': {
           'PolicyName': names.policyScale(this.table, this.read),
           'PolicyType': 'TargetTrackingScaling',

--- a/src/aws/policy.js
+++ b/src/aws/policy.js
@@ -22,10 +22,7 @@ class Policy {
     return {
       [names.policyScale(this.table, this.read, this.index, this.stage)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalingPolicy',
-        'DependsOn': [
-          this.table,
-          names.target(this.table, this.read, this.index, this.stage)
-        ].concat(this.dependencies),
+        'DependsOn': [ this.table, names.target(this.table, this.read, this.index, this.stage) ].concat(this.dependencies),
         'Properties': {
           'PolicyName': names.policyScale(this.table, this.read, this.index, this.stage),
           'PolicyType': 'TargetTrackingScaling',

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -18,9 +18,7 @@ class Role {
     return {
       [names.role(this.table, this.index, this.stage)]: {
         'Type': 'AWS::IAM::Role',
-        'DependsOn': [
-          this.table
-        ].concat(this.dependencies),
+        'DependsOn': [ this.table ].concat(this.dependencies),
         'Properties': {
           'RoleName': names.role(this.table, this.index, this.stage),
           'AssumeRolePolicyDocument': {

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -7,7 +7,7 @@ class Role {
     this.dependencies = []
   }
 
-  setDependencies(list) {
+  setDependencies (list) {
     this.dependencies = list
   }
 

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -9,6 +9,8 @@ class Role {
 
   setDependencies (list) {
     this.dependencies = list
+
+    return this
   }
 
   toJSON () {

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -9,6 +9,9 @@ class Role {
     return {
       [names.role(this.table)]: {
         'Type': 'AWS::IAM::Role',
+        'DependsOn': [
+          this.table
+        ],
         'Properties': {
           'RoleName': names.role(this.table),
           'AssumeRolePolicyDocument': {
@@ -46,7 +49,7 @@ class Role {
                       'dynamodb:DescribeTable',
                       'dynamodb:UpdateTable'
                     ],
-                    'Resource': { 'Fn::Join': [ '', [ 'arn:aws:dynamodb:*:', { 'Ref': 'AWS::AccountId' }, ':table/' + this.table ] ] }
+                    'Resource': { 'Fn::Join': [ '', [ 'arn:aws:dynamodb:*:', { 'Ref': 'AWS::AccountId' }, ':table/', { 'Ref': this.table } ] ] }
                   }
                 ]
               }

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -1,17 +1,12 @@
 const names = require('./names')
 
 class Role {
-  constructor (table) {
+  constructor (table, index) {
     this.table = table
+    this.index = index
   }
 
   toJSON () {
-    const resource = [ 'arn:aws:dynamodb:*:', { 'Ref': 'AWS::AccountId' }, ':table/', { 'Ref': this.table } ]
-
-    if (this.index) {
-      resource.push('/index/', this.index)
-    }
-
     return {
       [names.role(this.table, this.index)]: {
         'Type': 'AWS::IAM::Role',
@@ -55,7 +50,7 @@ class Role {
                       'dynamodb:DescribeTable',
                       'dynamodb:UpdateTable'
                     ],
-                    'Resource': { 'Fn::Join': [ '', resource ] }
+                    'Resource': { 'Fn::Join': [ '', [ 'arn:aws:dynamodb:*:', { 'Ref': 'AWS::AccountId' }, ':table/', { 'Ref': this.table } ] ] }
                   }
                 ]
               }

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -4,6 +4,11 @@ class Role {
   constructor (table, index) {
     this.table = table
     this.index = index
+    this.dependencies = []
+  }
+
+  setDependencies(list) {
+    this.dependencies = list
   }
 
   toJSON () {
@@ -12,7 +17,7 @@ class Role {
         'Type': 'AWS::IAM::Role',
         'DependsOn': [
           this.table
-        ],
+        ].concat(this.dependencies),
         'Properties': {
           'RoleName': names.role(this.table, this.index),
           'AssumeRolePolicyDocument': {

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -6,14 +6,20 @@ class Role {
   }
 
   toJSON () {
+    const resource = [ 'arn:aws:dynamodb:*:', { 'Ref': 'AWS::AccountId' }, ':table/', { 'Ref': this.table } ]
+
+    if (this.index) {
+      resource.push('/index/', this.index)
+    }
+
     return {
-      [names.role(this.table)]: {
+      [names.role(this.table, this.index)]: {
         'Type': 'AWS::IAM::Role',
         'DependsOn': [
           this.table
         ],
         'Properties': {
-          'RoleName': names.role(this.table),
+          'RoleName': names.role(this.table, this.index),
           'AssumeRolePolicyDocument': {
             'Version': '2012-10-17',
             'Statement': [
@@ -28,7 +34,7 @@ class Role {
           },
           'Policies': [
             {
-              'PolicyName': names.policyRole(this.table),
+              'PolicyName': names.policyRole(this.table, this.index),
               'PolicyDocument': {
                 'Version': '2012-10-17',
                 'Statement': [
@@ -49,7 +55,7 @@ class Role {
                       'dynamodb:DescribeTable',
                       'dynamodb:UpdateTable'
                     ],
-                    'Resource': { 'Fn::Join': [ '', [ 'arn:aws:dynamodb:*:', { 'Ref': 'AWS::AccountId' }, ':table/', { 'Ref': this.table } ] ] }
+                    'Resource': { 'Fn::Join': [ '', resource ] }
                   }
                 ]
               }

--- a/src/aws/role.js
+++ b/src/aws/role.js
@@ -1,9 +1,10 @@
 const names = require('./names')
 
 class Role {
-  constructor (table, index) {
+  constructor (table, index, stage) {
     this.table = table
     this.index = index
+    this.stage = stage
     this.dependencies = []
   }
 
@@ -15,13 +16,13 @@ class Role {
 
   toJSON () {
     return {
-      [names.role(this.table, this.index)]: {
+      [names.role(this.table, this.index, this.stage)]: {
         'Type': 'AWS::IAM::Role',
         'DependsOn': [
           this.table
         ].concat(this.dependencies),
         'Properties': {
-          'RoleName': names.role(this.table, this.index),
+          'RoleName': names.role(this.table, this.index, this.stage),
           'AssumeRolePolicyDocument': {
             'Version': '2012-10-17',
             'Statement': [
@@ -36,7 +37,7 @@ class Role {
           },
           'Policies': [
             {
-              'PolicyName': names.policyRole(this.table, this.index),
+              'PolicyName': names.policyRole(this.table, this.index, this.stage),
               'PolicyDocument': {
                 'Version': '2012-10-17',
                 'Statement': [

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -27,10 +27,7 @@ class Target {
     return {
       [names.target(this.table, this.read, this.index, this.stage)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalableTarget',
-        'DependsOn': [
-          this.table,
-          names.role(this.table, this.index, this.stage)
-        ].concat(this.dependencies),
+        'DependsOn': [ this.table, names.role(this.table, this.index, this.stage) ].concat(this.dependencies),
         'Properties': {
           'MaxCapacity': this.max,
           'MinCapacity': this.min,

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -1,4 +1,3 @@
-const util = require('util')
 const names = require('./names')
 
 class Target {
@@ -13,11 +12,14 @@ class Target {
     return {
       [names.target(this.table, this.read)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalableTarget',
-        'DependsOn': names.role(this.table),
+        'DependsOn': [
+          this.table,
+          names.role(this.table)
+        ],
         'Properties': {
           'MaxCapacity': this.max,
           'MinCapacity': this.min,
-          'ResourceId': util.format('table/%s', this.table),
+          'ResourceId': { 'Fn::Join': [ '', [ 'table/', { 'Ref': this.table } ] ] },
           'RoleARN': { 'Fn::GetAtt': [ names.role(this.table), 'Arn' ] },
           'ScalableDimension': names.dimension(this.read),
           'ServiceNamespace': 'dynamodb'

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -10,8 +10,8 @@ class Target {
     this.dependencies = []
   }
 
-  setDependencies(list) {
-    this.dependencies = list 
+  setDependencies (list) {
+    this.dependencies = list
   }
 
   toJSON () {

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -9,18 +9,24 @@ class Target {
   }
 
   toJSON () {
+    const resource = [ 'table/', { 'Ref': this.table } ]
+
+    if (this.index) {
+      resource.push('/index/', this.index)
+    }
+
     return {
-      [names.target(this.table, this.read)]: {
+      [names.target(this.table, this.read, this.index)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalableTarget',
         'DependsOn': [
           this.table,
-          names.role(this.table)
+          names.role(this.table, this.index)
         ],
         'Properties': {
           'MaxCapacity': this.max,
           'MinCapacity': this.min,
           'ResourceId': { 'Fn::Join': [ '', [ 'table/', { 'Ref': this.table } ] ] },
-          'RoleARN': { 'Fn::GetAtt': [ names.role(this.table), 'Arn' ] },
+          'RoleARN': { 'Fn::GetAtt': [ names.role(this.table, this.index), 'Arn' ] },
           'ScalableDimension': names.dimension(this.read),
           'ServiceNamespace': 'dynamodb'
         }

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -36,7 +36,7 @@ class Target {
           'MinCapacity': this.min,
           'ResourceId': { 'Fn::Join': [ '', resource ] },
           'RoleARN': { 'Fn::GetAtt': [ names.role(this.table, this.index, this.stage), 'Arn' ] },
-          'ScalableDimension': names.dimension(this.read, this.index, this.stage),
+          'ScalableDimension': names.dimension(this.read, this.index),
           'ServiceNamespace': 'dynamodb'
         }
       }

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -7,6 +7,11 @@ class Target {
     this.min = parseInt(min, 10)
     this.max = parseInt(max, 10)
     this.read = !!read
+    this.dependencies = []
+  }
+
+  setDependencies(list) {
+    this.dependencies = list 
   }
 
   toJSON () {
@@ -22,7 +27,7 @@ class Target {
         'DependsOn': [
           this.table,
           names.role(this.table, this.index)
-        ],
+        ].concat(this.dependencies),
         'Properties': {
           'MaxCapacity': this.max,
           'MinCapacity': this.min,

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -1,8 +1,9 @@
 const names = require('./names')
 
 class Target {
-  constructor (table, min, max, read) {
+  constructor (table, min, max, read, index) {
     this.table = table
+    this.index = index
     this.min = parseInt(min, 10)
     this.max = parseInt(max, 10)
     this.read = !!read
@@ -25,9 +26,9 @@ class Target {
         'Properties': {
           'MaxCapacity': this.max,
           'MinCapacity': this.min,
-          'ResourceId': { 'Fn::Join': [ '', [ 'table/', { 'Ref': this.table } ] ] },
+          'ResourceId': { 'Fn::Join': [ '', resource ] },
           'RoleARN': { 'Fn::GetAtt': [ names.role(this.table, this.index), 'Arn' ] },
-          'ScalableDimension': names.dimension(this.read),
+          'ScalableDimension': names.dimension(this.read, this.index),
           'ServiceNamespace': 'dynamodb'
         }
       }

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -1,9 +1,10 @@
 const names = require('./names')
 
 class Target {
-  constructor (table, min, max, read, index) {
+  constructor (table, min, max, read, index, stage) {
     this.table = table
     this.index = index
+    this.stage = stage
     this.min = parseInt(min, 10)
     this.max = parseInt(max, 10)
     this.read = !!read
@@ -24,18 +25,18 @@ class Target {
     }
 
     return {
-      [names.target(this.table, this.read, this.index)]: {
+      [names.target(this.table, this.read, this.index, this.stage)]: {
         'Type': 'AWS::ApplicationAutoScaling::ScalableTarget',
         'DependsOn': [
           this.table,
-          names.role(this.table, this.index)
+          names.role(this.table, this.index, this.stage)
         ].concat(this.dependencies),
         'Properties': {
           'MaxCapacity': this.max,
           'MinCapacity': this.min,
           'ResourceId': { 'Fn::Join': [ '', resource ] },
-          'RoleARN': { 'Fn::GetAtt': [ names.role(this.table, this.index), 'Arn' ] },
-          'ScalableDimension': names.dimension(this.read, this.index),
+          'RoleARN': { 'Fn::GetAtt': [ names.role(this.table, this.index, this.stage), 'Arn' ] },
+          'ScalableDimension': names.dimension(this.read, this.index, this.stage),
           'ServiceNamespace': 'dynamodb'
         }
       }

--- a/src/aws/target.js
+++ b/src/aws/target.js
@@ -12,6 +12,8 @@ class Target {
 
   setDependencies (list) {
     this.dependencies = list
+
+    return this
   }
 
   toJSON () {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -28,7 +28,7 @@ class Plugin {
 
   defaults (config) {
     return {
-      name: config.name,
+      table: config.table,
       read: {
         usage: config.read && config.read.usage ? config.read.usage : 0.75,
         minimum: config.read && config.read.minimum ? config.read.minimum : 5,
@@ -48,7 +48,7 @@ class Plugin {
         // Skip set if no read or write scaling configuration is available
         if (!config.read && !config.write) {
           return this.serverless.cli.log(
-            util.format(' - Skipping configuration for table "%s"', config.name)
+            util.format(' - Skipping configuration for resource "%s"', config.table)
           )
         }
 
@@ -58,25 +58,25 @@ class Plugin {
 
         // Start processing configuration
         this.serverless.cli.log(
-          util.format(' - Adding configuration for table "%s"', table.name)
+          util.format(' - Adding configuration for resource "%s"', table.table)
         )
 
         // Add role to manage Auto Scaling policies
-        resources.push(new Role(table.name))
+        resources.push(new Role(table.table))
 
         // Only add Auto Scaling for read capacity if configuration set is available
         if (config.read) {
           resources.push(
-            new Policy(table.name, table.read.usage, true, 60, 60),
-            new Target(table.name, table.read.minimum, table.read.maximum, true)
+            new Policy(table.table, table.read.usage, true, 60, 60),
+            new Target(table.table, table.read.minimum, table.read.maximum, true)
           )
         }
 
         // Only add Auto Scaling for write capacity if configuration set is available
         if (config.write) {
           resources.push(
-            new Policy(table.name, table.write.usage, false, 60, 60),
-            new Target(table.name, table.write.minimum, table.write.maximum, false)
+            new Policy(table.table, table.write.usage, false, 60, 60),
+            new Target(table.table, table.write.minimum, table.write.maximum, false)
           )
         }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -17,8 +17,6 @@ class Plugin {
     this.hooks = {
       'deploy:compileEvents': this.beforeDeployResources.bind(this)
     }
-
-    console.log()
   }
 
   /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -135,19 +135,15 @@ class Plugin {
   /**
    * Check if parameter is defined and return as array if only a string is provided
    *
-   * @param {stirng|array} data
+   * @param {array|string} data
    * @return {array}
    */
   normalize (data) {
-    if (!data) {
-      return []
+    if (data && data.constructor !== Array) {
+      return [ data.toString() ]
     }
 
-    if (data.constructor !== Array) {
-      return [data]
-    }
-
-    return data.slice(0)
+    return (data || []).slice(0)
   }
 
   /**
@@ -178,27 +174,19 @@ class Plugin {
         }
       )
     }
-
-    return Promise.resolve()
   }
 
   beforeDeployResources () {
     return Promise.resolve().then(
-      this.validate.bind(this)
+      () => this.validate()
     ).then(
-      () => this.serverless.cli.log(
-        util.format('Configure DynamoDB Auto Scaling …')
-      )
+      () => this.serverless.cli.log(util.format('Configure DynamoDB Auto Scaling …'))
     ).then(
-      this.process.bind(this)
+      () => this.process()
     ).then(
-      () => this.serverless.cli.log(
-        util.format('Added DynamoDB Auto Scaling to CloudFormation!')
-      )
+      () => this.serverless.cli.log(util.format('Added DynamoDB Auto Scaling to CloudFormation!'))
     ).catch(
-      err => this.serverless.cli.log(
-        util.format('Skipping DynamoDB Auto Scaling: %s!', err.message)
-      )
+      er => this.serverless.cli.log(util.format('Skipping DynamoDB Auto Scaling: %s!', er.message))
     )
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -152,28 +152,18 @@ class Plugin {
    * @return {Promise}
    */
   process () {
-    if (this.serverless.service.custom) {
-      this.serverless.service.custom.capacities.forEach(
-        config => {
-          // Skip set if no read or write scaling configuration is available
-          if (!config.read && !config.write) {
-            return this.serverless.cli.log(
-              util.format(' - Skipping configuration for resource "%s"', config.table)
-            )
-          }
-
-          // Walk every table in configuration
-          this.normalize(config.table).forEach(
-            table => this.generate(table, config).forEach(
-              resource => _.merge(
-                this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-                resource
-              )
-            )
+    this.serverless.service.custom.capacities.filter(
+      config => !!config.read || !!config.write
+    ).forEach(
+      config => this.normalize(config.table).forEach(
+        table => this.generate(table, config).forEach(
+          resource => _.merge(
+            this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+            resource
           )
-        }
+        )
       )
-    }
+    )
   }
 
   beforeDeployResources () {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,8 +9,8 @@ const Policy = require('./aws/policy')
 class Plugin {
   /**
    * Constructur
-   * 
-   * @param {object} serverless 
+   *
+   * @param {object} serverless
    */
   constructor (serverless) {
     this.serverless = serverless
@@ -35,8 +35,8 @@ class Plugin {
 
   /**
    * Parse configuration and fill up with default values when needed
-   * 
-   * @param {object} config 
+   *
+   * @param {object} config
    * @return {object}
    */
   defaults (config) {
@@ -56,15 +56,15 @@ class Plugin {
 
   /**
    * Create CloudFormation resources for table (and optional index)
-   * 
-   * @param {string} table 
-   * @param {string} index 
-   * @param {object} config 
+   *
+   * @param {string} table
+   * @param {string} index
+   * @param {object} config
    */
   resources (table, index, config) {
     const resources = []
     const data = this.defaults(config)
-    
+
     // Start processing configuration
     this.serverless.cli.log(
       util.format(' - Building configuration for resource "table/%s%s"', table, (index ? ('/index/' + index) : ''))
@@ -96,9 +96,9 @@ class Plugin {
 
   /**
    * Generate CloudFormation resources for DynamoDB table and indexes
-   * 
-   * @param {string} table 
-   * @param {obejct} config 
+   *
+   * @param {string} table
+   * @param {obejct} config
    */
   generate (table, config) {
     let resources = []
@@ -125,8 +125,8 @@ class Plugin {
 
   /**
    * Check if parameter is defined and return as array if only a string is provided
-   * 
-   * @param {stirng|array} data 
+   *
+   * @param {stirng|array} data
    * @return {array}
    */
   normalize (data) {
@@ -137,13 +137,13 @@ class Plugin {
     if (data.constructor !== Array) {
       return [data]
     }
-    
+
     return data.slice(0)
   }
 
   /**
    * Process the provided configuration
-   * 
+   *
    * @return {Promise}
    */
   process () {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -68,6 +68,8 @@ class Plugin {
         new Target(data.table, data.write.minimum, data.write.maximum, false)
       )
     }
+
+    return resources
   }
 
   process () {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -87,7 +87,6 @@ class Plugin {
       item => Object.keys(item.toJSON()).pop()
     )
 
-
     return resources.map(
       resource => {
         resource.setDependencies(deps)
@@ -119,7 +118,7 @@ class Plugin {
 
           tables.forEach(table => {
             const resources = this.resources(table, config, config.index, lastRessources)
-            
+
             // Inject templates in serverless CloudFormation template
             resources.forEach(
               resource => _.merge(

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,6 +6,12 @@ const Role = require('./aws/role')
 const Target = require('./aws/target')
 const Policy = require('./aws/policy')
 
+const text = {
+  INVALID_CONFIGURATION: 'Invalid serverless configuration',
+  ONLY_AWS_SUPPORT: 'Only supported for AWS provicer',
+  NO_AUTOSCALING_CONFIG: 'Not Auto Scaling configuration found'
+}
+
 class Plugin {
   /**
    * Constructur
@@ -23,16 +29,16 @@ class Plugin {
    * Validate the request and check if configuration is available
    */
   validate () {
-    assert(this.serverless, 'Invalid serverless configuration')
-    assert(this.serverless.service, 'Invalid serverless configuration')
-    assert(this.serverless.service.provider, 'Invalid serverless configuration')
-    assert(this.serverless.service.provider.name, 'Invalid serverless configuration')
-    assert(this.serverless.service.provider.name === 'aws', 'Only supported for AWS provider')
+    assert(this.serverless, text.INVALID_CONFIGURATION)
+    assert(this.serverless.service, text.INVALID_CONFIGURATION)
+    assert(this.serverless.service.provider, text.INVALID_CONFIGURATION)
+    assert(this.serverless.service.provider.name, text.INVALID_CONFIGURATION)
+    assert(this.serverless.service.provider.name === 'aws', text.ONLY_AWS_SUPPORT)
 
-    assert(this.serverless.service.provider.stage, 'Invalid serverless configuration')
+    assert(this.serverless.service.provider.stage, text.INVALID_CONFIGURATION)
 
-    assert(this.serverless.service.custom, 'Not Auto Scaling configuration found')
-    assert(this.serverless.service.custom.capacities, 'Not Auto Scaling configuration found')
+    assert(this.serverless.service.custom, text.NO_AUTOSCALING_CONFIG)
+    assert(this.serverless.service.custom.capacities, text.NO_AUTOSCALING_CONFIG)
   }
 
   /**
@@ -101,7 +107,7 @@ class Plugin {
    * Generate CloudFormation resources for DynamoDB table and indexes
    *
    * @param {string} table
-   * @param {obejct} config
+   * @param {object} config
    */
   generate (table, config) {
     let resources = []

--- a/test/aws/names.spec.js
+++ b/test/aws/names.spec.js
@@ -15,6 +15,10 @@ describe('Names', () => {
     expect(names.role('test-with-invalid-characters')).toBe('DynamoDBAutoscaleRoletestwithinvalidcharacters')
   })
 
+  it('creates name for Role with index and stage', () => {
+    expect(names.role('test-with-invalid-characters', 'index', 'stage')).toBe('DynamoDBAutoscaleRoletestwithinvalidcharactersindexstage')
+  })
+
   it('creates name for Metric (read)', () => {
     expect(names.metric(true)).toBe('DynamoDBReadCapacityUtilization')
   })

--- a/test/aws/target.spec.js
+++ b/test/aws/target.spec.js
@@ -11,10 +11,8 @@ describe('Target', () => {
     const d = j[names.target('my-table-name', true)]
 
     expect(d).toHaveProperty('Type', 'AWS::ApplicationAutoScaling::ScalableTarget')
-    expect(d).toHaveProperty('DependsOn', names.role('my-table-name'))
     expect(d).toHaveProperty('Properties.MinCapacity', 4)
     expect(d).toHaveProperty('Properties.MaxCapacity', 100)
-    expect(d).toHaveProperty('Properties.ResourceId', 'table/my-table-name')
     expect(d).toHaveProperty('Properties.ScalableDimension', names.dimension(true))
     expect(d).toHaveProperty('Properties.ServiceNamespace', 'dynamodb')
     expect(d).toHaveProperty('Properties.RoleARN.Fn::GetAtt')
@@ -30,10 +28,8 @@ describe('Target', () => {
     const d = j[names.target('my-table-name', false)]
 
     expect(d).toHaveProperty('Type', 'AWS::ApplicationAutoScaling::ScalableTarget')
-    expect(d).toHaveProperty('DependsOn', names.role('my-table-name'))
     expect(d).toHaveProperty('Properties.MinCapacity', 100)
     expect(d).toHaveProperty('Properties.MaxCapacity', 2000)
-    expect(d).toHaveProperty('Properties.ResourceId', 'table/my-table-name')
     expect(d).toHaveProperty('Properties.ScalableDimension', names.dimension(false))
     expect(d).toHaveProperty('Properties.ServiceNamespace', 'dynamodb')
     expect(d).toHaveProperty('Properties.RoleARN.Fn::GetAtt')

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -9,6 +9,7 @@ describe('Normalize', () => {
     expect(test.normalize('test')).toEqual(['test'])
     expect(test.normalize(['test'])).toEqual(['test'])
     expect(test.normalize(['test', 'foo'])).toEqual(['test', 'foo'])
+    expect(test.normalize([])).toEqual([])
     expect(test.normalize()).toEqual([])
   })
 })

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -2,27 +2,33 @@
 
 const Plugin = require('../')
 
-it('creates CloudFormation configuration', () => {
-  let config = {
-    service: {
-      custom: {
-        'dynamodb-autoscaling': [
-          { name: 'table-name' }
-        ]
-      },
-      provider: {
-        region: 'test-region',
-        compiledCloudFormationTemplate: {
-          Resources: {}
-        }
-      }
+describe('Normalize', () => {
+  it('converts everything to an array', () => {
+    const test = new Plugin()
+    
+    expect(test.normalize('test')).toEqual(['test'])
+    expect(test.normalize(['test'])).toEqual(['test'])
+    expect(test.normalize(['test', 'foo'])).toEqual(['test', 'foo'])
+    expect(test.normalize()).toEqual([])
+  })
+})
+
+describe('Defaults', () => {
+  it('creates object with defaults', () => {
+    let config = { 
+      read: { maximum: 100, usage: 1 },
+      write: { minimum: 20 }
     }
-  }
 
-  const test = new Plugin(config)
-  test.beforeDeployResources()
+    const test = new Plugin()
+    const data = test.defaults(config)
 
-  // const data = config.service.provider.compiledCloudFormationTemplate.Resources
+    expect(data.read.minimum).toBe(5)
+    expect(data.read.maximum).toBe(100)
+    expect(data.read.usage).toBe(1)
 
-  expect(true).toBe(true)
+    expect(data.write.minimum).toBe(20)
+    expect(data.write.maximum).toBe(200)
+    expect(data.write.usage).toBe(0.75)
+  })
 })

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -5,7 +5,7 @@ const Plugin = require('../')
 describe('Normalize', () => {
   it('converts everything to an array', () => {
     const test = new Plugin()
-    
+
     expect(test.normalize('test')).toEqual(['test'])
     expect(test.normalize(['test'])).toEqual(['test'])
     expect(test.normalize(['test', 'foo'])).toEqual(['test', 'foo'])
@@ -15,7 +15,7 @@ describe('Normalize', () => {
 
 describe('Defaults', () => {
   it('creates object with defaults', () => {
-    let config = { 
+    let config = {
       read: { maximum: 100, usage: 1 },
       write: { minimum: 20 }
     }


### PR DESCRIPTION
* `table` property supports string and array as value(s)
* Support for `index` property to scale `GlobalSecondaryIndexes` #2 

### Tasks

* [x] Rewrite index support
* [x] Rewrite `DependsOn` handling
* [x] Update `README.md` 
* [x] Add info about [CloudWatch API rate limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html)
* [x] Add stage to naming schema
* [x] Extend tests for `names.js`

This branch supports flexible Auto Scaling for tables and/or global secondary indexes with the following configurations:

```yaml
custom:
  capacities:
    - table: CustomTableA
      index: custom-index-global
      indexOnly: true
      read:
        minimum: 1
        maximum: 123
        usage: 0.80
      write:
        minimum: 10
        maximum: 100
        usage: 0.50
    - table: CustomTableB
      read:
        minimum: 1
        maximum: 123
        usage: 0.80
      write:
        minimum: 10
        maximum: 100
        usage: 0.50
    - table:
        - CustomTableC
        - CustomTableD
        - CustomTableE
      index:
        - custom-index
      read:
        minimum: 1
        maximum: 123
        usage: 0.80
      write:
        minimum: 10
        maximum: 100
        usage: 0.50
```