### PR TITLE
Truncate names that are longer than 64 characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "standard": "^10.0.2"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "md5": "^2.2.1"
   },
   "standard": {
     "envs": [

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -2,11 +2,15 @@ const util = require('util')
 const md5 = require('md5')
 
 function clean (input) {
-  return turncate(input.replace(/[^a-z0-9+]+/gi, ''))
+  return truncate(input.replace(/[^a-z0-9+]+/gi, ''))
 }
 
-function turncate (input) {
-  return input.length > 64 ? md5(input) : input
+function truncate (input) {
+  if (input.length > 64) {
+    return util.format('%s%s', input.substr(0, 32), md5(input))
+  }
+
+  return input
 }
 
 function policyScale (table, read, index, stage) {

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -1,7 +1,12 @@
 const util = require('util')
+const md5 = require('md5')
 
 function clean (input) {
-  return input.replace(/[^a-z0-9+]+/gi, '')
+  return turncate(input.replace(/[^a-z0-9+]+/gi, ''))
+}
+
+function turncate (input) {
+  return input.length > 64 ? md5(input) : input
 }
 
 function policyScale (table, read, index, stage) {

--- a/src/aws/names.js
+++ b/src/aws/names.js
@@ -6,11 +6,7 @@ function clean (input) {
 }
 
 function truncate (input) {
-  if (input.length > 64) {
-    return util.format('%s%s', input.substr(0, 32), md5(input))
-  }
-
-  return input
+  return input.length <= 64 ? input : input.substr(0, 32) + md5(input)
 }
 
 function policyScale (table, read, index, stage) {

--- a/test/aws/role.spec.js
+++ b/test/aws/role.spec.js
@@ -11,6 +11,18 @@ describe('Role', () => {
     const d = j[names.role('my-table-name')]
 
     expect(d).toHaveProperty('Type', 'AWS::IAM::Role')
-    expect(d).toHaveProperty('Properties.RoleName', names.role('my-table-name'))
+    expect(d).toHaveProperty('Properties.RoleName', 'DynamoDBAutoscaleRolemytablename')
+  })
+
+  it('truncates role name if needed', () => {
+    const r = new Role('my-table-name-with-some-extra-long-string-information-added-to-the-end')
+    const j = r.toJSON()
+
+    expect(j).toHaveProperty(names.role('my-table-name-with-some-extra-long-string-information-added-to-the-end'))
+
+    const d = j[names.role('my-table-name-with-some-extra-long-string-information-added-to-the-end')]
+    
+    expect(d.Properties.RoleName.length).toBeLessThan(65)
+    expect(d).toHaveProperty('Properties.RoleName', '0cde19b63d7d9f9b35cd41a979fd72a2')
   })
 })

--- a/test/aws/role.spec.js
+++ b/test/aws/role.spec.js
@@ -22,7 +22,7 @@ describe('Role', () => {
 
     const d = j[names.role('my-table-name-with-some-extra-long-string-information-added-to-the-end')]
 
-    expect(d.Properties.RoleName.length).toBeLessThan(65)
-    expect(d).toHaveProperty('Properties.RoleName', '0cde19b63d7d9f9b35cd41a979fd72a2')
+    expect(d.Properties.RoleName.length).toBe(64)
+    expect(d).toHaveProperty('Properties.RoleName', 'DynamoDBAutoscaleRolemytablename0cde19b63d7d9f9b35cd41a979fd72a2')
   })
 })

--- a/test/aws/role.spec.js
+++ b/test/aws/role.spec.js
@@ -21,7 +21,7 @@ describe('Role', () => {
     expect(j).toHaveProperty(names.role('my-table-name-with-some-extra-long-string-information-added-to-the-end'))
 
     const d = j[names.role('my-table-name-with-some-extra-long-string-information-added-to-the-end')]
-    
+
     expect(d.Properties.RoleName.length).toBeLessThan(65)
     expect(d).toHaveProperty('Properties.RoleName', '0cde19b63d7d9f9b35cd41a979fd72a2')
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,10 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
@@ -506,6 +510,10 @@ coveralls@^2.13.1:
     log-driver "1.2.5"
     minimist "1.2.0"
     request "2.79.0"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -1242,7 +1250,7 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
@@ -1850,6 +1858,14 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 merge@^1.1.3:
   version "1.2.0"


### PR DESCRIPTION
This should fix #9 

If the name is longer than 64 characters, I use a `md5` hash instead.