### PR TITLE
rename Plugin class in AWSDBAutoScaling

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,7 +21,7 @@ interface Defaults {
   write: CapacityConfiguration
 }
 
-class Plugin {
+class AWSDBAutoScaling {
   public hooks: {}
 
   /**
@@ -203,4 +203,4 @@ class Plugin {
   }
 }
 
-module.exports = Plugin
+module.exports = AWSDBAutoScaling


### PR DESCRIPTION
Hi,

To fix issue : https://github.com/sbstjn/serverless-dynamodb-autoscaling/issues/23
With Serverless 1.22
I had to rename the plugin Class "Plugin" into another name.

Regards,
Fef